### PR TITLE
Use `OS::Nova::Server` instead of `Rackspace::Cloud::Server`

### DIFF
--- a/mongodb-replset-peers.yaml
+++ b/mongodb-replset-peers.yaml
@@ -76,7 +76,7 @@ parameters:
 resources:
 
   mongodb_peer_server:
-    type: "Rackspace::Cloud::Server"
+    type: "OS::Nova::Server"
     properties:
       name: { get_param: server_hostname }
       flavor: { get_param: flavor }
@@ -112,7 +112,7 @@ resources:
             replicaset: false
           config:
             replSet: myreplset
-            bind_ip: 0.0.0.0     # { get_attr: [mongodb_peer_server, privateIPv4] }
+            bind_ip: 0.0.0.0     # { get_attr: [mongodb_peer_server, networks, private, 0] }
         run_list: [ "recipe[apt]",
                     "recipe[build-essential]",
                     "recipe[install_packages]",
@@ -126,7 +126,7 @@ outputs:
     description: "Server IP"
 
   privateIPv4:
-    value: { get_attr: [mongodb_peer_server, privateIPv4] }
+    value: { get_attr: [mongodb_peer_server, networks, private, 0] }
     description: the private ip of the peer server
 
   accessIPv4:

--- a/mongodb-replset-peers.yaml
+++ b/mongodb-replset-peers.yaml
@@ -99,6 +99,9 @@ resources:
         apt:
           compile_time_update: true
         mongodb:
+          ruby_gems:
+            mongo: '1.12.0'
+            bson_ext: '1.12.0'
           default_init_name: mongod
           instance_name: mongod
           dbconfig_file: /etc/mongod.conf

--- a/mongodb-replset-peers.yaml
+++ b/mongodb-replset-peers.yaml
@@ -115,7 +115,7 @@ resources:
             replicaset: false
           config:
             replSet: myreplset
-            bind_ip: 0.0.0.0     # { get_attr: [mongodb_peer_server, networks, private, 0] }
+            bind_ip: 0.0.0.0
         run_list: [ "recipe[apt]",
                     "recipe[build-essential]",
                     "recipe[install_packages]",

--- a/mongodb-replset.yaml
+++ b/mongodb-replset.yaml
@@ -135,6 +135,9 @@ resources:
       chef_version: { get_param: chef_version }
       node:
         mongodb:
+          ruby_gems:
+            mongo: '1.12.0'
+            bson_ext: '1.12.0'
           bind_ip: { get_attr: [mongodb_peer_servers, privateIPv4, 0] }
           use_fqdn: false
           replicaset_members: { get_attr: [mongodb_peer_servers, privateIPv4] }

--- a/site-cookbooks/config_replset/recipes/default.rb
+++ b/site-cookbooks/config_replset/recipes/default.rb
@@ -1,4 +1,6 @@
-chef_gem 'mongo'
+chef_gem 'mongo' do
+  version '1.12.0'
+end
 
 ruby_block 'config replset' do
   block do


### PR DESCRIPTION
`Rackspace::Cloud::Server` is deprecated.

[rubygems.org](https://rubygems.org) updated [the mongodb gem](https://rubygems.org/gems/mongo) to v2.0, which changes the interface the mongo cookbooks and our mongo cluster config cookbook use. Fixing the versions of mongo and bson_ext to the latest 1.x version, 1.12.0, allows the cookbooks to still function with this new version in [rubygems.org](https://rubygems.org).

This fixes #25.